### PR TITLE
review: stermi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/aave-v3-origin-private"]
 	path = lib/aave-v3-origin-private
-	url = https://github.com/bgd-labs/aave-v3-origin-private
-	branch = v3.4.0-clean
+	url = https://github.com/bgd-labs/aave-v3-origin-stermi
+	branch = v3.4.0
 [submodule "lib/GhoDirectMinter"]
 	path = lib/GhoDirectMinter
 	url = https://github.com/bgd-labs/GhoDirectMinter


### PR DESCRIPTION
While for other repos we did a private fork for each auditor, in this case we share the same repo with everyone because otherwise we'd have a different git hash for each audit (given we need to change the origin reference on the submodule).

You can properly setup the submodule by running:
```
git submodule sync --recursive
```